### PR TITLE
fix: Citizens NPCによる死亡（EntityDeathEvent）の記録を除外する

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'net.coreprotect'
-String projectVersion = '21.2'
+String projectVersion = '21.2-1'
 String projectBranch = ''
 version = projectVersion // `version` might be modified, we don't always want that (e.g. plugin.yml)
 description = 'Provides block protection for your server.'

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>net.coreprotect</groupId>
   <artifactId>CoreProtect</artifactId>
-  <version>21.2</version>
+  <version>21.2-1</version>
   <properties>
     <project.branch>development</project.branch>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/net/coreprotect/listener/entity/EntityDeathListener.java
+++ b/src/main/java/net/coreprotect/listener/entity/EntityDeathListener.java
@@ -523,6 +523,9 @@ public final class EntityDeathListener extends Queue implements Listener {
         if (entity == null) {
             return;
         }
+        if(entity.hasMetadata("NPC")){
+            return;
+        }
 
         logEntityDeath(entity, null);
     }


### PR DESCRIPTION
close #1 

`EntityDeathEvent` 発火時に `NPC` メタデータがついているかどうかで判定。